### PR TITLE
Add start row selection for Excel scans

### DIFF
--- a/app/src/main/java/com/example/ip/FileHelper.java
+++ b/app/src/main/java/com/example/ip/FileHelper.java
@@ -14,7 +14,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -22,8 +22,10 @@ public class FileHelper {
 
     private static final String TAG = "FileHelper";
 
-    public static List<String> loadIps(Context ctx, Uri uri) {
-        Set<String> ips = new HashSet<>(); // чтобы не было дубликатов
+    public static List<String> loadIps(Context ctx, Uri uri, int startRow) {
+        if (startRow < 1) startRow = 1;
+
+        Set<String> ips = new LinkedHashSet<>(); // сохраняем порядок и убираем дубликаты
         try {
             String name = uri.getLastPathSegment().toLowerCase();
 
@@ -35,6 +37,7 @@ public class FileHelper {
                     for (int s = 0; s < wb.getNumberOfSheets(); s++) {
                         Sheet sheet = wb.getSheetAt(s);
                         for (Row row : sheet) {
+                            if (row.getRowNum() + 1 < startRow) continue;
                             for (Cell cell : row) {
                                 String text = cell.toString().trim();
                                 if (text.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
@@ -48,8 +51,11 @@ public class FileHelper {
                 // Читаем CSV или TXT
                 try (BufferedReader br = new BufferedReader(
                         new InputStreamReader(ctx.getContentResolver().openInputStream(uri)))) {
+                    int currentRow = 0;
                     String line;
                     while ((line = br.readLine()) != null) {
+                        currentRow++;
+                        if (currentRow < startRow) continue;
                         // Разделяем по запятой, точке с запятой или пробелу
                         String[] parts = line.split("[,;\\s]+");
                         for (String part : parts) {

--- a/app/src/main/java/com/example/ip/MainActivity.java
+++ b/app/src/main/java/com/example/ip/MainActivity.java
@@ -15,6 +15,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.text.method.ScrollingMovementMethod;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import java.io.BufferedReader;
@@ -25,6 +26,7 @@ public class MainActivity extends AppCompatActivity {
 
     private TextView tvOutput;
     private Button btnPickFile, btnStart;
+    private EditText etStartRow;
     private Uri pickedFileUri;
     private ActivityResultLauncher<String[]> filePickerLauncher;
 
@@ -41,6 +43,7 @@ public class MainActivity extends AppCompatActivity {
         tvOutput = findViewById(R.id.tvOutput);
         btnPickFile = findViewById(R.id.btnPickFile);
         btnStart = findViewById(R.id.btnStart);
+        etStartRow = findViewById(R.id.etStartRow);
 
         // разрешаем прокрутку текста руками
         tvOutput.setMovementMethod(new ScrollingMovementMethod());
@@ -70,8 +73,19 @@ public class MainActivity extends AppCompatActivity {
             }
 
             // запуск воркера
+            int startRow = 1;
+            String startRowText = etStartRow.getText() != null ? etStartRow.getText().toString().trim() : "";
+            if (!startRowText.isEmpty()) {
+                try {
+                    startRow = Math.max(1, Integer.parseInt(startRowText));
+                } catch (NumberFormatException e) {
+                    startRow = 1;
+                }
+            }
+
             Data inputData = new Data.Builder()
                     .putString(ScanWorker.KEY_FILE_URI, pickedFileUri.toString())
+                    .putInt(ScanWorker.KEY_START_ROW, startRow)
                     .build();
 
             OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(ScanWorker.class)

--- a/app/src/main/java/com/example/ip/ScanWorker.java
+++ b/app/src/main/java/com/example/ip/ScanWorker.java
@@ -21,6 +21,7 @@ public class ScanWorker extends Worker {
 
     public static final String KEY_FILE_URI = "fileUri";
     private static final String TAG = "ScanWorker";
+    public static final String KEY_START_ROW = "startRow";
 
     public ScanWorker(@NonNull Context context, @NonNull WorkerParameters params) {
         super(context, params);
@@ -43,7 +44,8 @@ public class ScanWorker extends Worker {
 
         try {
             Uri uri = Uri.parse(getInputData().getString(KEY_FILE_URI));
-            List<String> ips = FileHelper.loadIps(getApplicationContext(), uri);
+            int startRow = getInputData().getInt(KEY_START_ROW, 1);
+            List<String> ips = FileHelper.loadIps(getApplicationContext(), uri, startRow);
 
             if (ips == null || ips.isEmpty()) {
                 Log.w(TAG, "Список IP пуст!");
@@ -54,7 +56,7 @@ public class ScanWorker extends Worker {
 
             // 🔥 очищаем лог и пишем заголовок
             try (BufferedWriter clear = new BufferedWriter(new FileWriter(logFile, false))) {
-                clear.write("=== Начало проверки (" + ips.size() + " адресов) ===\n");
+                clear.write("=== Начало проверки (" + ips.size() + " адресов, старт с строки " + startRow + ") ===\n");
             }
 
             int total = ips.size();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,6 +11,14 @@
         android:layout_height="wrap_content"
         android:text="Выбрать файл" />
 
+    <EditText
+        android:id="@+id/etStartRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="С какой строки начать (по умолчанию 1)"
+        android:inputType="number"
+        android:text="1" />
+
     <Button
         android:id="@+id/btnStart"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- add an input field to choose the starting row before launching the scan
- forward the selected row to the worker and include it in the log header
- skip Excel/CSV rows prior to the chosen start and keep IP order when loading addresses

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e111241468832bbded25076d89048b